### PR TITLE
Add isHitting getter to HitBuffer and update rendering logic in TopologyLayer

### DIFF
--- a/client/src/src/template/api/utils.ts
+++ b/client/src/src/template/api/utils.ts
@@ -8,7 +8,6 @@ export function extractIPFromUrl(url: string): string {
 }
 
 export function decodeNodeInfo(nodeInfo: string): { address: string, nodeKey: string} {
-    console.log('decodeNodeInfo...', nodeInfo)
     const isRemote = nodeInfo.includes('::')
     if (isRemote) {
         const [address, nodeKey] = nodeInfo.split('::')

--- a/client/src/src/views/mapView/topology/TopologyLayer.ts
+++ b/client/src/src/views/mapView/topology/TopologyLayer.ts
@@ -740,7 +740,9 @@ export default class TopologyLayer implements NHCustomLayerInterface {
         // Tick render
         if (!this.isTransparent) {
             // Mesh Pass
-            this.drawCellMeshes()
+            if (this.hitBuffer.isHitting)
+                console.log('rendering meshes')
+                this.drawCellMeshes()
             // Line Pass
             this.drawCellLines()
         }

--- a/client/src/src/views/mapView/topology/TopologyLayer.ts
+++ b/client/src/src/views/mapView/topology/TopologyLayer.ts
@@ -741,7 +741,6 @@ export default class TopologyLayer implements NHCustomLayerInterface {
         if (!this.isTransparent) {
             // Mesh Pass
             if (this.hitBuffer.isHitting)
-                console.log('rendering meshes')
                 this.drawCellMeshes()
             // Line Pass
             this.drawCellLines()

--- a/client/src/src/views/mapView/topology/hitBuffer.ts
+++ b/client/src/src/views/mapView/topology/hitBuffer.ts
@@ -25,6 +25,10 @@ export default class HitBuffer {
         }
     }
 
+    get isHitting(): boolean {
+        return this._hitCount > 0
+    }
+
     isHit(index: number): boolean {
         return this._hitBuffer[index] != 0
     }


### PR DESCRIPTION
Introduce an `isHitting` getter in the `HitBuffer` class to determine if hits are present. Update the rendering logic in `TopologyLayer` to conditionally draw cell meshes based on the hit status, while removing unnecessary debug logs.