### PR TITLE
Implement vector draft modes with undo/redo functionality

### DIFF
--- a/client/src/src/template/vector/vectorCheck.tsx
+++ b/client/src/src/template/vector/vectorCheck.tsx
@@ -55,6 +55,7 @@ export default function VectorCheck({ node, context }: VectorCheckProps) {
     const mapContext = context as MapViewContext
     const map = mapContext.map!
     const drawInstance = mapContext.drawInstance!
+    const panelLayerId = node.key
 
     const pageContext = useRef<PageContext>({
         drawVector: null,
@@ -80,7 +81,7 @@ export default function VectorCheck({ node, context }: VectorCheckProps) {
     const loadContext = async () => {
         if (!(node as ResourceNode).lockId) {
             store.get<{ on: Function, off: Function }>('isLoading')!.on()
-            const linkResponse = await linkNode("gridmen/IVector/1.0.0", node.nodeInfo, "w");
+            const linkResponse = await linkNode("gridmen/IVector/1.0.0", node.nodeInfo, "r");
             (node as ResourceNode).lockId = linkResponse.lock_id
             store.get<{ on: Function, off: Function }>('isLoading')!.off()
         }
@@ -101,8 +102,9 @@ export default function VectorCheck({ node, context }: VectorCheckProps) {
         const fcCopy: GeoJSON.FeatureCollection = JSON.parse(JSON.stringify(pageContext.current.drawVector!))
         tagVectorColor(fcCopy, hex)
         const handle = addVectorDisplay(map, node.nodeInfo, fcCopy)
+        handle.setVisible(true)
         pageContext.current.displayHandle = handle;
-        layerOrderCoordinator.register(node.nodeInfo, handle.mapboxLayerIds);
+        layerOrderCoordinator.register(panelLayerId, handle.mapboxLayerIds);
 
         (node as ResourceNode).context = {
             ...((node as ResourceNode).context ?? {}),
@@ -112,7 +114,7 @@ export default function VectorCheck({ node, context }: VectorCheckProps) {
                     pageContext.current.displayHandle?.remove()
                     pageContext.current.displayHandle = null
                     pageContext.current.checkedVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo)
+                    layerOrderCoordinator.unregister(panelLayerId)
                 }
             },
         }
@@ -133,7 +135,7 @@ export default function VectorCheck({ node, context }: VectorCheckProps) {
                     pageContext.current.displayHandle?.remove()
                     pageContext.current.displayHandle = null
                     pageContext.current.checkedVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo)
+                    layerOrderCoordinator.unregister(panelLayerId)
                 }
             },
         }

--- a/client/src/src/template/vector/vectorCreation.tsx
+++ b/client/src/src/template/vector/vectorCreation.tsx
@@ -19,6 +19,12 @@ import { Dot, Globe, Minus, MousePointer, Palette, Pencil, Redo2, SplinePointer,
 import store from '@/store/store'
 import { addVectorDisplay, tagVectorColor, VectorDisplayHandle } from '@/views/mapView/vectorDisplayLayer'
 import { layerOrderCoordinator } from '@/views/mapView/layerOrderCoordinator'
+import {
+    VECTOR_DRAFT_LINE_MODE,
+    VECTOR_DRAFT_POLYGON_MODE,
+    type VectorDraftModeController,
+} from './vectorDraftDrawModes'
+import type { VectorDraftSnapshot } from './vectorDraftUndoManager'
 
 interface VectorCreationProps {
     node: IResourceNode
@@ -39,6 +45,7 @@ interface PageContext {
     vectorFilePath: string | null
     createdVectorIds: Set<string>
     displayHandle: VectorDisplayHandle | null
+    draftSnapshot: VectorDraftSnapshot | null
 }
 
 const vectorTips = [
@@ -52,6 +59,7 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
     const mapContext = context as MapViewContext
     const map = mapContext.map!
     const drawInstance = mapContext.drawInstance!
+    const panelLayerId = node.key
 
     const pageContext = useRef<PageContext>({
         hasVector: false,
@@ -68,8 +76,10 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
         vectorFilePath: null,
         createdVectorIds: new Set<string>(),
         displayHandle: null,
+        draftSnapshot: null,
     })
 
+    const draftController = useRef<VectorDraftModeController>({ current: null })
     const [, triggerRepaint] = useReducer(x => x + 1, 0)
 
     const getNodeFeatures = (): GeoJSON.FeatureCollection => {
@@ -84,6 +94,86 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
             type: 'FeatureCollection',
             features: nodeFeatures
         }
+    }
+
+    const isDraftPendingType = (type: PageContext['pendingType']) => type === 'line' || type === 'polygon'
+
+    const handleDraftChange = (snapshot: VectorDraftSnapshot | null) => {
+        pageContext.current.draftSnapshot = snapshot
+        triggerRepaint()
+    }
+
+    const startDrawMode = (snapshot?: VectorDraftSnapshot | null) => {
+        const pendingType = pageContext.current.pendingType
+        const drawInstanceMode = getDrawInstanceModeByType(pendingType)
+
+        if (!isDraftPendingType(pendingType)) {
+            pageContext.current.draftSnapshot = null
+            draftController.current.current = null
+            ; (drawInstance as any).changeMode(drawInstanceMode)
+            return
+        }
+
+        const draftSnapshot =
+            snapshot?.type === pendingType
+                ? snapshot
+                : pageContext.current.draftSnapshot?.type === pendingType
+                    ? pageContext.current.draftSnapshot
+                    : null
+
+        ; (drawInstance as any).changeMode(drawInstanceMode, {
+            snapshot: draftSnapshot,
+            controller: draftController.current,
+            color: getHexColorByValue(pageContext.current.vectorData.color),
+            onDraftChange: handleDraftChange,
+        })
+    }
+
+    const pauseActiveDraft = () => {
+        const activeDraft = draftController.current.current
+        if (!activeDraft) {
+            return false
+        }
+        if (activeDraft.snapshot().coordinates.length === 0) {
+            activeDraft.cancel()
+            return true
+        }
+        activeDraft.pause()
+        return true
+    }
+
+    const finalizeActiveDraftForSave = () => {
+        const activeDraft = draftController.current.current
+        if (!activeDraft) return true
+
+        if (activeDraft.snapshot().coordinates.length === 0) {
+            activeDraft.cancel()
+            return true
+        }
+
+        if (!activeDraft.canFinalize()) {
+            toast.error('Current vector draft is not complete. Finish or cancel it before saving.')
+            return false
+        }
+
+        pageContext.current.drawingMode = 'select'
+        activeDraft.finalize()
+        return true
+    }
+
+    const canUndoDraft = () => pageContext.current.drawingMode === 'draw' && draftController.current.current?.canUndo() === true
+    const canRedoDraft = () => pageContext.current.drawingMode === 'draw' && draftController.current.current?.canRedo() === true
+
+    const handleUndoDraft = () => {
+        if (!canUndoDraft()) return
+        draftController.current.current?.undo()
+        triggerRepaint()
+    }
+
+    const handleRedoDraft = () => {
+        if (!canRedoDraft()) return
+        draftController.current.current?.redo()
+        triggerRepaint()
     }
 
     useEffect(() => {
@@ -110,12 +200,12 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
             const handle = addVectorDisplay(map, node.nodeInfo, empty)
             handle.setVisible(false)
             pageContext.current.displayHandle = handle
-            layerOrderCoordinator.register(node.nodeInfo, handle.mapboxLayerIds)
+            layerOrderCoordinator.register(panelLayerId, handle.mapboxLayerIds)
         }
 
         if (pageContext.current.hasVector) {
-            (drawInstance as any).changeMode(getDrawInstanceModeByType(pageContext.current.pendingType))
             pageContext.current.drawingMode = "draw"
+            startDrawMode(pageContext.current.draftSnapshot)
         }
 
         (node as ResourceNode).context = {
@@ -141,7 +231,9 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
                     }
                     drawInstance.delete(featureIds)
                     pageContext.current.createdVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo)
+                    pageContext.current.draftSnapshot = null
+                    draftController.current.current = null
+                    layerOrderCoordinator.unregister(panelLayerId)
                 }
             },
         }
@@ -151,7 +243,10 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
 
     const unloadContext = () => {
         if (drawInstance) {
-            (drawInstance as any).changeMode('simple_select');
+            const draftPaused = pauseActiveDraft()
+            if (!draftPaused) {
+                (drawInstance as any).changeMode('simple_select');
+            }
         }
         (node as ResourceNode).context = {
             ...pageContext.current,
@@ -176,7 +271,9 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
                     }
                     drawInstance.delete(featureIds)
                     pageContext.current.createdVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo)
+                    pageContext.current.draftSnapshot = null
+                    draftController.current.current = null
+                    layerOrderCoordinator.unregister(panelLayerId)
                 }
             },
         }
@@ -202,8 +299,7 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
             triggerRepaint()
 
             if (pageContext.current.drawingMode === "draw") {
-                const drawInstanceMode = getDrawInstanceModeByType(pageContext.current.pendingType)
-                setTimeout(() => (drawInstance as any).changeMode(drawInstanceMode), 0)
+                setTimeout(() => startDrawMode(), 0)
             }
         }
 
@@ -248,9 +344,9 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
             case "point":
                 return "draw_point"
             case "line":
-                return "draw_line_string"
+                return VECTOR_DRAFT_LINE_MODE
             case "polygon":
-                return "draw_polygon"
+                return VECTOR_DRAFT_POLYGON_MODE
             default:
                 return "simple_select"
         }
@@ -280,8 +376,7 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
     const handleClickConfirm = async () => {
         if (pageContext.current.tabState === "draw") {
             console.log('Creating vector with drawn features:', pageContext.current.pendingType)
-            const drawInstanceMode = getDrawInstanceModeByType(pageContext.current.pendingType);
-            (drawInstance as any).changeMode(drawInstanceMode)
+            startDrawMode()
 
             pageContext.current.hasVector = true
             pageContext.current.drawingMode = "draw"
@@ -327,15 +422,19 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
 
     const handleClickDraw = () => {
         pageContext.current.drawingMode = "draw"
-        const drawInstanceMode = getDrawInstanceModeByType(pageContext.current.pendingType);
-        (drawInstance as any).changeMode(drawInstanceMode)
+        startDrawMode()
 
         triggerRepaint()
     }
 
     const handleClickSelect = () => {
         pageContext.current.drawingMode = "select";
-        (drawInstance as any).changeMode('simple_select')
+        const activeDraft = draftController.current.current
+        if (activeDraft) {
+            activeDraft.finalize()
+        } else {
+            (drawInstance as any).changeMode('simple_select')
+        }
 
         triggerRepaint()
     }
@@ -371,7 +470,62 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
         triggerRepaint()
     }
 
+    useEffect(() => {
+        const isEditableTarget = (target: EventTarget | null) => {
+            const el = target as HTMLElement | null
+            if (!el) return false
+            if (el.isContentEditable) return true
+            const tag = el.tagName?.toUpperCase()
+            return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT"
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) return
+            if (isEditableTarget(event.target)) return
+
+            const isCommand = event.ctrlKey || event.metaKey
+            if (isCommand) {
+                const key = event.key.toLowerCase()
+                if (key === 'z' && event.shiftKey) {
+                    event.preventDefault()
+                    handleRedoDraft()
+                    return
+                }
+                if (key === 'z') {
+                    event.preventDefault()
+                    handleUndoDraft()
+                    return
+                }
+                if (key === 'y') {
+                    event.preventDefault()
+                    handleRedoDraft()
+                    return
+                }
+                if (key === 'd') {
+                    event.preventDefault()
+                    handleClickDraw()
+                    return
+                }
+                if (key === 's') {
+                    event.preventDefault()
+                    handleClickSelect()
+                    return
+                }
+            }
+
+            if (event.key === 'Delete') {
+                event.preventDefault()
+                handleClickDelete()
+            }
+        }
+
+        window.addEventListener("keydown", handleKeyDown)
+        return () => window.removeEventListener("keydown", handleKeyDown)
+    })
+
     const handleCreateVector = async () => {
+        if (!finalizeActiveDraftForSave()) return
+
         const newVector = {
             name: pageContext.current.vectorData.name,
             color: pageContext.current.vectorData.color,
@@ -493,12 +647,26 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
                             <div>
                                 <h3 className="text-white font-semibold mb-2">Operations</h3>
                                 <div className="grid grid-cols-3 gap-2">
-                                    <button className="bg-slate-700/50 hover:bg-slate-600/50 border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all cursor-pointer">
+                                    <button
+                                        onClick={handleUndoDraft}
+                                        disabled={!canUndoDraft()}
+                                        className={`${canUndoDraft()
+                                            ? "bg-slate-700/50 hover:bg-slate-600/50 cursor-pointer"
+                                            : "bg-slate-700/50 opacity-50 cursor-not-allowed"}
+                                                border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all`}
+                                    >
                                         <Undo2 className="h-4 w-4" />
                                         <span>Undo</span>
                                         <span className="text-xs opacity-80">[ Ctrl+Z ]</span>
                                     </button>
-                                    <button className="bg-slate-700/50 hover:bg-slate-600/50 border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all cursor-pointer">
+                                    <button
+                                        onClick={handleRedoDraft}
+                                        disabled={!canRedoDraft()}
+                                        className={`${canRedoDraft()
+                                            ? "bg-slate-700/50 hover:bg-slate-600/50 cursor-pointer"
+                                            : "bg-slate-700/50 opacity-50 cursor-not-allowed"}
+                                                border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all`}
+                                    >
                                         <Redo2 className="h-4 w-4" />
                                         <span>Redo</span>
                                         <span className="text-xs opacity-80">[ Ctrl+Y ]</span>
@@ -569,6 +737,7 @@ export default function VectorCreation({ node, context }: VectorCreationProps) {
                                         onValueChange={(value: any) => {
                                             pageContext.current.vectorData.color = value
                                             const hex = getHexColorByValue(value)
+                                            draftController.current.current?.setColor(hex)
                                             for (const fid of pageContext.current.createdVectorIds) {
                                                 drawInstance.setFeatureProperty(fid, "color", hex)
                                             }

--- a/client/src/src/template/vector/vectorDraftDrawModes.ts
+++ b/client/src/src/template/vector/vectorDraftDrawModes.ts
@@ -1,0 +1,499 @@
+import {
+    VectorDraftUndoManager,
+    type VectorDraftCoordinate,
+    type VectorDraftGeometryType,
+    type VectorDraftSnapshot,
+} from './vectorDraftUndoManager'
+
+export const VECTOR_DRAFT_LINE_MODE = 'vector_draw_line_string'
+export const VECTOR_DRAFT_POLYGON_MODE = 'vector_draw_polygon'
+
+export interface VectorDraftModeHandle {
+    type: VectorDraftGeometryType
+    featureId: string
+    undo: () => void
+    redo: () => void
+    pause: () => void
+    finalize: () => void
+    cancel: () => void
+    canUndo: () => boolean
+    canRedo: () => boolean
+    canFinalize: () => boolean
+    snapshot: () => VectorDraftSnapshot
+    setColor: (color: string) => void
+}
+
+export interface VectorDraftModeController {
+    current: VectorDraftModeHandle | null
+}
+
+export interface VectorDraftModeOptions {
+    snapshot?: VectorDraftSnapshot | null
+    controller?: VectorDraftModeController
+    color?: string
+    onDraftChange?: (snapshot: VectorDraftSnapshot | null, status: 'active' | 'paused' | 'finalized' | 'cancelled') => void
+}
+
+interface DraftLngLat {
+    lng: number
+    lat: number
+}
+
+interface DraftMapEvent {
+    lngLat: DraftLngLat
+    featureTarget?: {
+        properties?: {
+            meta?: string
+        }
+    }
+}
+
+type DraftKeyboardEvent = KeyboardEvent
+
+interface DraftDoubleClickZoomControl {
+    disable: () => void
+    enable: () => void
+}
+
+interface DrawFeature {
+    id: string
+    setCoordinates: (coordinates: VectorDraftCoordinate[] | VectorDraftCoordinate[][]) => void
+    setProperty: (key: string, value: string) => void
+    toGeoJSON: () => GeoJSON.Feature
+}
+
+interface DraftFeatureInput {
+    id?: string
+    type: 'Feature'
+    properties: Record<string, unknown>
+    geometry: {
+        type: 'LineString' | 'Polygon'
+        coordinates: VectorDraftCoordinate[] | VectorDraftCoordinate[][]
+    }
+}
+
+type DraftDisplayFeature = GeoJSON.Feature<GeoJSON.LineString | GeoJSON.Polygon> & {
+    properties: Record<string, unknown> & {
+        id?: string
+        active?: string
+        meta?: string
+    }
+}
+
+interface DrawModeContext {
+    map?: {
+        doubleClickZoom?: DraftDoubleClickZoomControl
+    }
+    _ctx?: {
+        store?: {
+            getInitialConfigValue?: (key: string) => unknown
+        }
+    }
+    newFeature: (feature: DraftFeatureInput) => DrawFeature
+    addFeature: (feature: DrawFeature) => void
+    clearSelectedFeatures: () => void
+    updateUIClasses: (options: { mouse: string }) => void
+    activateUIButton: (name?: string) => void
+    setActionableState: (actions: { trash?: boolean }) => void
+    changeMode: (mode: string, options?: Record<string, unknown>, eventOptions?: { silent?: boolean }) => void
+    deleteFeature: (featureIds: string[], options?: { silent?: boolean }) => void
+    getFeature: (featureId: string) => DrawFeature | undefined
+    fire: (eventName: string, eventData: { features: GeoJSON.Feature[] }) => void
+}
+
+interface VectorDraftModeState {
+    type: VectorDraftGeometryType
+    feature: DrawFeature
+    manager: VectorDraftUndoManager
+    controller?: VectorDraftModeController
+    cursorCoordinate: VectorDraftCoordinate | null
+    stopAction: 'finalize' | 'pause' | 'cancel'
+    onDraftChange?: VectorDraftModeOptions['onDraftChange']
+}
+
+const geojsonTypes = {
+    FEATURE: 'Feature',
+    LINE_STRING: 'LineString',
+    POLYGON: 'Polygon',
+    POINT: 'Point',
+} as const
+
+const cursors = {
+    ADD: 'add',
+    POINTER: 'pointer',
+    NONE: 'none',
+} as const
+
+const drawTypes = {
+    LINE: 'line_string',
+    POLYGON: 'polygon',
+} as const
+
+const events = {
+    CREATE: 'draw.create',
+} as const
+
+const meta = {
+    FEATURE: 'feature',
+    VERTEX: 'vertex',
+} as const
+
+const activeStates = {
+    ACTIVE: 'true',
+    INACTIVE: 'false',
+} as const
+
+const cloneCoordinate = (coordinate: VectorDraftCoordinate): VectorDraftCoordinate => [
+    coordinate[0],
+    coordinate[1],
+]
+
+const getEventCoordinate = (event: DraftMapEvent): VectorDraftCoordinate => [
+    event.lngLat.lng,
+    event.lngLat.lat,
+]
+
+const isVertexEvent = (event: DraftMapEvent): boolean =>
+    event.featureTarget?.properties?.meta === meta.VERTEX
+
+const isEnterKey = (event: DraftKeyboardEvent): boolean => event.key === 'Enter' || event.keyCode === 13
+
+const isEscapeKey = (event: DraftKeyboardEvent): boolean => event.key === 'Escape' || event.keyCode === 27
+
+const isEventAtCoordinate = (event: DraftMapEvent, coordinate: VectorDraftCoordinate | undefined): boolean => {
+    if (!event.lngLat || !coordinate) return false
+    return event.lngLat.lng === coordinate[0] && event.lngLat.lat === coordinate[1]
+}
+
+const createVertex = (parentId: string, coordinates: VectorDraftCoordinate, path: string): GeoJSON.Feature => ({
+    type: geojsonTypes.FEATURE,
+    properties: {
+        meta: meta.VERTEX,
+        parent: parentId,
+        coord_path: path,
+        active: activeStates.INACTIVE,
+    },
+    geometry: {
+        type: geojsonTypes.POINT,
+        coordinates,
+    },
+})
+
+const disableDoubleClickZoom = (ctx: DrawModeContext) => {
+    setTimeout(() => ctx.map?.doubleClickZoom?.disable?.(), 0)
+}
+
+const enableDoubleClickZoom = (ctx: DrawModeContext) => {
+    setTimeout(() => {
+        const enabledInitially = ctx._ctx?.store?.getInitialConfigValue?.('doubleClickZoom')
+        if (enabledInitially !== false) ctx.map?.doubleClickZoom?.enable?.()
+    }, 0)
+}
+
+const getActiveCoordinates = (manager: VectorDraftUndoManager, cursorCoordinate: VectorDraftCoordinate | null) => {
+    const coordinates = manager.getCoordinates()
+    if (cursorCoordinate) return [...coordinates, cloneCoordinate(cursorCoordinate)]
+    const lastCoordinate = coordinates[coordinates.length - 1]
+    return lastCoordinate ? [...coordinates, cloneCoordinate(lastCoordinate)] : coordinates
+}
+
+const applyFeatureCoordinates = (state: VectorDraftModeState) => {
+    const activeCoordinates = getActiveCoordinates(state.manager, state.cursorCoordinate)
+    if (state.type === 'line') {
+        state.feature.setCoordinates(activeCoordinates)
+    } else {
+        state.feature.setCoordinates([activeCoordinates])
+    }
+}
+
+const notifyActiveDraft = (state: VectorDraftModeState) => {
+    state.onDraftChange?.(state.manager.toSnapshot(), 'active')
+}
+
+const installController = (ctx: DrawModeContext, state: VectorDraftModeState) => {
+    const controller = state.controller
+    if (!controller) return
+
+    controller.current = {
+        type: state.type,
+        featureId: state.feature.id,
+        undo: () => {
+            state.manager.undo()
+            applyFeatureCoordinates(state)
+            notifyActiveDraft(state)
+        },
+        redo: () => {
+            state.manager.redo()
+            applyFeatureCoordinates(state)
+            notifyActiveDraft(state)
+        },
+        pause: () => {
+            state.stopAction = 'pause'
+            ctx.changeMode('simple_select', {}, { silent: true })
+        },
+        finalize: () => {
+            state.stopAction = 'finalize'
+            ctx.changeMode('simple_select', { featureIds: [state.feature.id] })
+        },
+        cancel: () => {
+            state.stopAction = 'cancel'
+            ctx.deleteFeature([state.feature.id], { silent: true })
+            ctx.changeMode('simple_select')
+        },
+        canUndo: () => state.manager.canUndo(),
+        canRedo: () => state.manager.canRedo(),
+        canFinalize: () => state.manager.canFinalize(),
+        snapshot: () => state.manager.toSnapshot(),
+        setColor: (color: string) => {
+            state.feature.setProperty('color', color)
+            applyFeatureCoordinates(state)
+        },
+    }
+}
+
+const clearController = (state: VectorDraftModeState) => {
+    const controller = state.controller
+    if (!controller) return
+    if (controller.current?.featureId === state.feature.id) {
+        controller.current = null
+    }
+}
+
+const createLineFeature = (ctx: DrawModeContext, snapshot?: VectorDraftSnapshot | null): DrawFeature => {
+    const coordinates = snapshot?.coordinates ?? []
+    return ctx.newFeature({
+        id: snapshot?.featureId,
+        type: geojsonTypes.FEATURE,
+        properties: {},
+        geometry: {
+            type: geojsonTypes.LINE_STRING,
+            coordinates,
+        },
+    })
+}
+
+const createPolygonFeature = (ctx: DrawModeContext, snapshot?: VectorDraftSnapshot | null): DrawFeature => {
+    const coordinates = snapshot?.coordinates ?? []
+    const ring = coordinates.length > 0 ? [...coordinates, coordinates[0]] : []
+    return ctx.newFeature({
+        id: snapshot?.featureId,
+        type: geojsonTypes.FEATURE,
+        properties: {},
+        geometry: {
+            type: geojsonTypes.POLYGON,
+            coordinates: [ring],
+        },
+    })
+}
+
+const setupDraftMode = (
+    ctx: DrawModeContext,
+    type: VectorDraftGeometryType,
+    options: VectorDraftModeOptions = {},
+): VectorDraftModeState => {
+    const feature = type === 'line'
+        ? createLineFeature(ctx, options.snapshot)
+        : createPolygonFeature(ctx, options.snapshot)
+
+    ctx.addFeature(feature)
+    if (options.color) feature.setProperty('color', options.color)
+
+    const manager = options.snapshot
+        ? VectorDraftUndoManager.fromSnapshot(options.snapshot)
+        : new VectorDraftUndoManager({
+            type,
+            featureId: feature.id,
+            coordinates: [],
+        })
+
+    const managerCoordinates = manager.getCoordinates()
+    const lastCoordinate = managerCoordinates[managerCoordinates.length - 1] ?? null
+    const state: VectorDraftModeState = {
+        type,
+        feature,
+        manager,
+        controller: options.controller,
+        cursorCoordinate: lastCoordinate,
+        stopAction: 'finalize',
+        onDraftChange: options.onDraftChange,
+    }
+
+    ctx.clearSelectedFeatures()
+    disableDoubleClickZoom(ctx)
+    ctx.updateUIClasses({ mouse: cursors.ADD })
+    ctx.activateUIButton(type === 'line' ? drawTypes.LINE : drawTypes.POLYGON)
+    ctx.setActionableState({ trash: true })
+
+    applyFeatureCoordinates(state)
+    installController(ctx, state)
+    notifyActiveDraft(state)
+
+    return state
+}
+
+const addVertex = (state: VectorDraftModeState, coordinate: VectorDraftCoordinate) => {
+    state.manager.addVertex(coordinate)
+    state.cursorCoordinate = coordinate
+    applyFeatureCoordinates(state)
+    notifyActiveDraft(state)
+}
+
+const finishIfValid = (ctx: DrawModeContext, state: VectorDraftModeState) => {
+    if (!state.manager.canFinalize()) return
+    state.stopAction = 'finalize'
+    ctx.changeMode('simple_select', { featureIds: [state.feature.id] })
+}
+
+const handleClick = (ctx: DrawModeContext, state: VectorDraftModeState, event: DraftMapEvent) => {
+    if (isVertexEvent(event)) {
+        finishIfValid(ctx, state)
+        return
+    }
+
+    const coordinates = state.manager.getCoordinates()
+    const lastCoordinate = coordinates[coordinates.length - 1]
+    if (coordinates.length > 0 && isEventAtCoordinate(event, lastCoordinate)) {
+        finishIfValid(ctx, state)
+        return
+    }
+
+    ctx.updateUIClasses({ mouse: cursors.ADD })
+    addVertex(state, getEventCoordinate(event))
+}
+
+const finalizeFeature = (ctx: DrawModeContext, state: VectorDraftModeState) => {
+    const coordinates = state.manager.getCoordinates()
+
+    if (!state.manager.canFinalize()) {
+        ctx.deleteFeature([state.feature.id], { silent: true })
+        state.onDraftChange?.(null, 'cancelled')
+        return
+    }
+
+    if (state.type === 'line') {
+        state.feature.setCoordinates(coordinates)
+    } else {
+        state.feature.setCoordinates([coordinates])
+    }
+
+    ctx.fire(events.CREATE, {
+        features: [state.feature.toGeoJSON()],
+    })
+    state.onDraftChange?.(null, 'finalized')
+}
+
+const stopDraftMode = (ctx: DrawModeContext, state: VectorDraftModeState) => {
+    ctx.updateUIClasses({ mouse: cursors.NONE })
+    enableDoubleClickZoom(ctx)
+    ctx.activateUIButton()
+
+    if (ctx.getFeature(state.feature.id) === undefined) {
+        clearController(state)
+        state.onDraftChange?.(null, 'cancelled')
+        return
+    }
+
+    if (state.stopAction === 'pause') {
+        state.onDraftChange?.(state.manager.toSnapshot(), 'paused')
+        ctx.deleteFeature([state.feature.id], { silent: true })
+        clearController(state)
+        return
+    }
+
+    if (state.stopAction === 'cancel') {
+        ctx.deleteFeature([state.feature.id], { silent: true })
+        state.onDraftChange?.(null, 'cancelled')
+        clearController(state)
+        return
+    }
+
+    finalizeFeature(ctx, state)
+    clearController(state)
+}
+
+const buildDraftMode = (type: VectorDraftGeometryType) => ({
+    onSetup(this: DrawModeContext, options: VectorDraftModeOptions = {}) {
+        return setupDraftMode(this, type, options)
+    },
+    onClick(this: DrawModeContext, state: VectorDraftModeState, event: DraftMapEvent) {
+        handleClick(this, state, event)
+    },
+    onTap(this: DrawModeContext, state: VectorDraftModeState, event: DraftMapEvent) {
+        handleClick(this, state, event)
+    },
+    onMouseMove(this: DrawModeContext, state: VectorDraftModeState, event: DraftMapEvent) {
+        state.cursorCoordinate = getEventCoordinate(event)
+        applyFeatureCoordinates(state)
+        this.updateUIClasses({ mouse: isVertexEvent(event) ? cursors.POINTER : cursors.ADD })
+    },
+    onKeyUp(this: DrawModeContext, state: VectorDraftModeState, event: DraftKeyboardEvent) {
+        if (isEscapeKey(event)) {
+            state.stopAction = 'cancel'
+            this.deleteFeature([state.feature.id], { silent: true })
+            this.changeMode('simple_select')
+        } else if (isEnterKey(event)) {
+            finishIfValid(this, state)
+        }
+    },
+    onTrash(this: DrawModeContext, state: VectorDraftModeState) {
+        state.stopAction = 'cancel'
+        this.deleteFeature([state.feature.id], { silent: true })
+        this.changeMode('simple_select')
+    },
+    onStop(this: DrawModeContext, state: VectorDraftModeState) {
+        stopDraftMode(this, state)
+    },
+    toDisplayFeatures(state: VectorDraftModeState, geojson: DraftDisplayFeature, display: (feature: GeoJSON.Feature) => void) {
+        const isActive = geojson.properties.id === state.feature.id
+        geojson.properties.active = isActive ? activeStates.ACTIVE : activeStates.INACTIVE
+        if (!isActive) {
+            display(geojson)
+            return
+        }
+
+        geojson.properties.meta = meta.FEATURE
+        const coordinates = state.manager.getCoordinates()
+
+        if (state.type === 'line') {
+            const line = geojson.geometry as GeoJSON.LineString
+            if (line.coordinates.length < 2) return
+            const lastIndex = coordinates.length - 1
+            if (lastIndex >= 0) {
+                display(createVertex(state.feature.id, coordinates[lastIndex], `${lastIndex}`))
+            }
+            display(geojson)
+            return
+        }
+
+        const polygon = geojson.geometry as GeoJSON.Polygon
+        if (polygon.coordinates.length === 0) return
+        const ring = polygon.coordinates[0]
+        if (!ring || ring.length < 3) return
+
+        if (coordinates[0]) {
+            display(createVertex(state.feature.id, coordinates[0], '0.0'))
+        }
+        if (coordinates.length > 2) {
+            const lastIndex = coordinates.length - 1
+            display(createVertex(state.feature.id, coordinates[lastIndex], `0.${lastIndex}`))
+        }
+
+        if (ring.length <= 4) {
+            if (ring.length === 3) return
+            display({
+                type: geojsonTypes.FEATURE,
+                properties: geojson.properties,
+                geometry: {
+                    type: geojsonTypes.LINE_STRING,
+                    coordinates: ring.slice(0, 2),
+                },
+            })
+            return
+        }
+
+        display(geojson)
+    },
+})
+
+export const VectorDraftLineMode = buildDraftMode('line')
+export const VectorDraftPolygonMode = buildDraftMode('polygon')

--- a/client/src/src/template/vector/vectorDraftUndoManager.ts
+++ b/client/src/src/template/vector/vectorDraftUndoManager.ts
@@ -1,0 +1,124 @@
+export type VectorDraftGeometryType = 'line' | 'polygon'
+export type VectorDraftCoordinate = [number, number]
+
+export interface VectorDraftOperation {
+    coordinate: VectorDraftCoordinate
+    index: number
+}
+
+export interface VectorDraftSnapshot {
+    type: VectorDraftGeometryType
+    featureId: string
+    coordinates: VectorDraftCoordinate[]
+    currentVertexPosition: number
+    undoStack: VectorDraftOperation[]
+    redoStack: VectorDraftOperation[]
+}
+
+export interface VectorDraftUndoManagerOptions {
+    type: VectorDraftGeometryType
+    featureId: string
+    coordinates?: VectorDraftCoordinate[]
+    undoStack?: VectorDraftOperation[]
+    redoStack?: VectorDraftOperation[]
+}
+
+const cloneCoordinate = (coordinate: VectorDraftCoordinate): VectorDraftCoordinate => [
+    coordinate[0],
+    coordinate[1],
+]
+
+const cloneCoordinates = (coordinates: VectorDraftCoordinate[] = []): VectorDraftCoordinate[] =>
+    coordinates.map(cloneCoordinate)
+
+const cloneOperations = (operations: VectorDraftOperation[] = []): VectorDraftOperation[] =>
+    operations.map((operation) => ({
+        index: operation.index,
+        coordinate: cloneCoordinate(operation.coordinate),
+    }))
+
+export class VectorDraftUndoManager {
+    readonly type: VectorDraftGeometryType
+    readonly featureId: string
+
+    private coordinates: VectorDraftCoordinate[]
+    private undoStack: VectorDraftOperation[]
+    private redoStack: VectorDraftOperation[]
+
+    constructor(options: VectorDraftUndoManagerOptions) {
+        this.type = options.type
+        this.featureId = options.featureId
+        this.coordinates = cloneCoordinates(options.coordinates)
+        this.undoStack = cloneOperations(options.undoStack)
+        this.redoStack = cloneOperations(options.redoStack)
+    }
+
+    static fromSnapshot(snapshot: VectorDraftSnapshot): VectorDraftUndoManager {
+        return new VectorDraftUndoManager(snapshot)
+    }
+
+    addVertex(coordinate: VectorDraftCoordinate): void {
+        const operation: VectorDraftOperation = {
+            index: this.coordinates.length,
+            coordinate: cloneCoordinate(coordinate),
+        }
+        this.coordinates.push(cloneCoordinate(coordinate))
+        this.undoStack.push(operation)
+        this.redoStack = []
+    }
+
+    undo(): VectorDraftCoordinate[] {
+        const operation = this.undoStack.pop()
+        if (!operation) return this.getCoordinates()
+
+        this.coordinates.splice(operation.index, 1)
+        this.redoStack.push(operation)
+        return this.getCoordinates()
+    }
+
+    redo(): VectorDraftCoordinate[] {
+        const operation = this.redoStack.pop()
+        if (!operation) return this.getCoordinates()
+
+        this.coordinates.splice(operation.index, 0, cloneCoordinate(operation.coordinate))
+        this.undoStack.push(operation)
+        return this.getCoordinates()
+    }
+
+    canUndo(): boolean {
+        return this.undoStack.length > 0
+    }
+
+    canRedo(): boolean {
+        return this.redoStack.length > 0
+    }
+
+    canFinalize(): boolean {
+        return this.type === 'line'
+            ? this.coordinates.length >= 2
+            : this.coordinates.length >= 3
+    }
+
+    hasCoordinates(): boolean {
+        return this.coordinates.length > 0
+    }
+
+    getCoordinates(): VectorDraftCoordinate[] {
+        return cloneCoordinates(this.coordinates)
+    }
+
+    getCurrentVertexPosition(): number {
+        return this.coordinates.length
+    }
+
+    toSnapshot(): VectorDraftSnapshot {
+        return {
+            type: this.type,
+            featureId: this.featureId,
+            coordinates: this.getCoordinates(),
+            currentVertexPosition: this.getCurrentVertexPosition(),
+            undoStack: cloneOperations(this.undoStack),
+            redoStack: cloneOperations(this.redoStack),
+        }
+    }
+}

--- a/client/src/src/template/vector/vectorEdit.tsx
+++ b/client/src/src/template/vector/vectorEdit.tsx
@@ -35,6 +35,12 @@ import type { IViewContext } from "@/views/IViewContext"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { addVectorDisplay, tagVectorColor, VectorDisplayHandle } from "@/views/mapView/vectorDisplayLayer"
 import { layerOrderCoordinator } from "@/views/mapView/layerOrderCoordinator"
+import {
+    VECTOR_DRAFT_LINE_MODE,
+    VECTOR_DRAFT_POLYGON_MODE,
+    type VectorDraftModeController,
+} from "./vectorDraftDrawModes"
+import type { VectorDraftSnapshot } from "./vectorDraftUndoManager"
 
 interface VectorEditProps {
     node: IResourceNode
@@ -52,6 +58,7 @@ interface PageContext {
     }
     editedVectorIds: Set<string>
     displayHandle: VectorDisplayHandle | null
+    draftSnapshot: VectorDraftSnapshot | null
 }
 
 const vectorTips = [
@@ -66,9 +73,9 @@ const getDrawInstanceModeByType = (type: "Point" | "Line" | "Polygon") => {
         case "Point":
             return "draw_point"
         case "Line":
-            return "draw_line_string"
+            return VECTOR_DRAFT_LINE_MODE
         case "Polygon":
-            return "draw_polygon"
+            return VECTOR_DRAFT_POLYGON_MODE
         default:
             return "simple_select"
     }
@@ -89,6 +96,7 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
     const mapContext = context as MapViewContext
     const map = mapContext.map!
     const drawInstance = mapContext.drawInstance!
+    const panelLayerId = node.key
 
     const pageContext = useRef<PageContext>({
         drawVector: null,
@@ -101,8 +109,10 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
         },
         editedVectorIds: new Set<string>(),
         displayHandle: null,
+        draftSnapshot: null,
     })
 
+    const draftController = useRef<VectorDraftModeController>({ current: null })
     const [, triggerRepaint] = useReducer((x) => x + 1, 0)
 
     const getNodeFeatures = (): GeoJSON.FeatureCollection => {
@@ -117,6 +127,89 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
             type: 'FeatureCollection',
             features: nodeFeatures
         }
+    }
+
+    const getDraftTypeByVectorType = (type: PageContext['vectorData']['type']) => {
+        if (type === 'Line') return 'line'
+        if (type === 'Polygon') return 'polygon'
+        return null
+    }
+
+    const handleDraftChange = (snapshot: VectorDraftSnapshot | null) => {
+        pageContext.current.draftSnapshot = snapshot
+        triggerRepaint()
+    }
+
+    const startDrawMode = (snapshot?: VectorDraftSnapshot | null) => {
+        const vectorType = pageContext.current.vectorData.type
+        const drawInstanceMode = getDrawInstanceModeByType(vectorType)
+        const draftType = getDraftTypeByVectorType(vectorType)
+
+        if (!draftType) {
+            pageContext.current.draftSnapshot = null
+            draftController.current.current = null
+            ; (drawInstance as any).changeMode(drawInstanceMode)
+            return
+        }
+
+        const draftSnapshot =
+            snapshot?.type === draftType
+                ? snapshot
+                : pageContext.current.draftSnapshot?.type === draftType
+                    ? pageContext.current.draftSnapshot
+                    : null
+
+        ; (drawInstance as any).changeMode(drawInstanceMode, {
+            snapshot: draftSnapshot,
+            controller: draftController.current,
+            color: getHexColorByValue(pageContext.current.vectorData.color),
+            onDraftChange: handleDraftChange,
+        })
+    }
+
+    const pauseActiveDraft = () => {
+        const activeDraft = draftController.current.current
+        if (!activeDraft) return false
+        if (activeDraft.snapshot().coordinates.length === 0) {
+            activeDraft.cancel()
+            return true
+        }
+        activeDraft.pause()
+        return true
+    }
+
+    const finalizeActiveDraftForSave = () => {
+        const activeDraft = draftController.current.current
+        if (!activeDraft) return true
+
+        if (activeDraft.snapshot().coordinates.length === 0) {
+            activeDraft.cancel()
+            return true
+        }
+
+        if (!activeDraft.canFinalize()) {
+            toast.error('Current vector draft is not complete. Finish or cancel it before saving.')
+            return false
+        }
+
+        pageContext.current.drawingMode = 'select'
+        activeDraft.finalize()
+        return true
+    }
+
+    const canUndoDraft = () => pageContext.current.drawingMode === 'draw' && draftController.current.current?.canUndo() === true
+    const canRedoDraft = () => pageContext.current.drawingMode === 'draw' && draftController.current.current?.canRedo() === true
+
+    const handleUndoDraft = () => {
+        if (!canUndoDraft()) return
+        draftController.current.current?.undo()
+        triggerRepaint()
+    }
+
+    const handleRedoDraft = () => {
+        if (!canRedoDraft()) return
+        draftController.current.current?.redo()
+        triggerRepaint()
     }
 
     useEffect(() => {
@@ -139,6 +232,11 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
             (node as ResourceNode).mountParams = vectorInfo.data
         }
 
+        const existingContext = (node as ResourceNode).context as Partial<PageContext> | undefined
+        if (existingContext?.draftSnapshot) {
+            pageContext.current.draftSnapshot = existingContext.draftSnapshot
+        }
+
         console.log(drawInstance)
 
         pageContext.current.vectorData.type = (node as ResourceNode).mountParams.feature_json?.features[0]?.geometry.type
@@ -153,7 +251,7 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
         const handle = addVectorDisplay(map, node.nodeInfo, fcCopy)
         handle.setVisible(false)
         pageContext.current.displayHandle = handle
-        layerOrderCoordinator.register(node.nodeInfo, handle.mapboxLayerIds)
+        layerOrderCoordinator.register(panelLayerId, handle.mapboxLayerIds)
 
         const addedIds = drawInstance.add(pageContext.current.drawVector!) as string[]
         addedIds.forEach((id) => pageContext.current.editedVectorIds.add(id))
@@ -161,6 +259,11 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
         for (const fid of pageContext.current.editedVectorIds) {
             drawInstance.setFeatureProperty(fid, "color", hex)
         };
+
+        if (pageContext.current.draftSnapshot) {
+            pageContext.current.drawingMode = 'draw'
+            startDrawMode(pageContext.current.draftSnapshot)
+        }
 
         (node as ResourceNode).context = {
             ...((node as ResourceNode).context ?? {}),
@@ -180,7 +283,9 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
                     }
                     drawInstance.delete(featureIds)
                     pageContext.current.editedVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo);
+                    pageContext.current.draftSnapshot = null
+                    draftController.current.current = null
+                    layerOrderCoordinator.unregister(panelLayerId);
                     (node as ResourceNode).mountParams = undefined
                 }
             },
@@ -191,7 +296,10 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
 
     const unloadContext = () => {
         if (drawInstance) {
-            (drawInstance as any).changeMode('simple_select');
+            const draftPaused = pauseActiveDraft()
+            if (!draftPaused) {
+                (drawInstance as any).changeMode('simple_select');
+            }
         }
         (node as ResourceNode).context = {
             ...pageContext.current,
@@ -211,7 +319,9 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
                     }
                     drawInstance.delete(featureIds)
                     pageContext.current.editedVectorIds.clear()
-                    layerOrderCoordinator.unregister(node.nodeInfo)
+                    pageContext.current.draftSnapshot = null
+                    draftController.current.current = null
+                    layerOrderCoordinator.unregister(panelLayerId)
                 }
             },
         }
@@ -237,8 +347,7 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
             triggerRepaint()
 
             if (pageContext.current.drawingMode === "draw") {
-                const drawInstanceMode = getDrawInstanceModeByType(pageContext.current.vectorData.type);
-                setTimeout(() => (drawInstance as any).changeMode(drawInstanceMode), 0)
+                setTimeout(() => startDrawMode(), 0)
             }
         }
 
@@ -283,15 +392,19 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
 
     const handleClickDraw = () => {
         pageContext.current.drawingMode = "draw"
-        const drawInstanceMode = getDrawInstanceModeByType(pageContext.current.vectorData.type);
-        (drawInstance as any).changeMode(drawInstanceMode)
+        startDrawMode()
 
         triggerRepaint()
     }
 
     const handleClickSelect = () => {
         pageContext.current.drawingMode = "select";
-        (drawInstance as any).changeMode('simple_select')
+        const activeDraft = draftController.current.current
+        if (activeDraft) {
+            activeDraft.finalize()
+        } else {
+            (drawInstance as any).changeMode('simple_select')
+        }
 
         triggerRepaint()
     }
@@ -315,21 +428,37 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
 
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.defaultPrevented) return
+            if (isEditableTarget(event.target)) return
 
             if (event.ctrlKey || event.metaKey) {
-                if (event.key === "D" || event.key === "d") {
+                const key = event.key.toLowerCase()
+                if (key === 'z' && event.shiftKey) {
+                    event.preventDefault()
+                    handleRedoDraft()
+                    return
+                }
+                if (key === 'z') {
+                    event.preventDefault()
+                    handleUndoDraft()
+                    return
+                }
+                if (key === 'y') {
+                    event.preventDefault()
+                    handleRedoDraft()
+                    return
+                }
+                if (key === "d") {
                     event.preventDefault()
                     handleClickDraw()
                     return
                 }
-                if (event.key === "S" || event.key === "s") {
+                if (key === "s") {
                     event.preventDefault()
                     handleClickSelect()
                     return
                 }
             }
             if (event.key === "Delete") {
-                if (isEditableTarget(event.target)) return
                 event.preventDefault()
                 handleDeleteSelected()
             }
@@ -337,7 +466,7 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
 
         window.addEventListener("keydown", handleKeyDown)
         return () => window.removeEventListener("keydown", handleKeyDown)
-    }, [handleClickSelect, handleDeleteSelected])
+    })
 
     const handleUpdateVector = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault()
@@ -354,10 +483,12 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
             return
         }
 
+        if (!finalizeActiveDraftForSave()) return
+
         const updateData = {
             color: pageContext.current.vectorData.color,
             epsg: pageContext.current.vectorData.epsg,
-            feature_json: pageContext.current.drawVector!,
+            feature_json: getNodeFeatures(),
         }
 
         pageContext.current.drawingMode = 'select';
@@ -443,12 +574,26 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
                             <div>
                                 <h3 className="text-white font-semibold mb-2">Operations</h3>
                                 <div className="grid grid-cols-3 gap-2">
-                                    <button className="bg-slate-700/50 hover:bg-slate-400/50 border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all cursor-pointer">
+                                    <button
+                                        onClick={handleUndoDraft}
+                                        disabled={!canUndoDraft()}
+                                        className={`${canUndoDraft()
+                                            ? "bg-slate-700/50 hover:bg-slate-400/50 cursor-pointer"
+                                            : "bg-slate-700/50 opacity-50 cursor-not-allowed"}
+                                                border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all`}
+                                    >
                                         <Undo2 className="h-4 w-4" />
                                         <span>Undo</span>
                                         <span className="text-xs opacity-80">[ Ctrl+Z ]</span>
                                     </button>
-                                    <button className="bg-slate-700/50 hover:bg-slate-400/50 border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all cursor-pointer">
+                                    <button
+                                        onClick={handleRedoDraft}
+                                        disabled={!canRedoDraft()}
+                                        className={`${canRedoDraft()
+                                            ? "bg-slate-700/50 hover:bg-slate-400/50 cursor-pointer"
+                                            : "bg-slate-700/50 opacity-50 cursor-not-allowed"}
+                                                border border-slate-600 text-white px-2 py-1 rounded-lg font-medium flex flex-col items-center justify-center gap-0.5 transition-all`}
+                                    >
                                         <Redo2 className="h-4 w-4" />
                                         <span>Redo</span>
                                         <span className="text-xs opacity-80">[ Ctrl+Y ]</span>
@@ -520,6 +665,7 @@ export default function VectorEdit({ node, context }: VectorEditProps) {
                                         onValueChange={(value: any) => {
                                             pageContext.current.vectorData.color = value
                                             const hex = getHexColorByValue(value)
+                                            draftController.current.current?.setColor(hex)
                                             for (const fid of pageContext.current.editedVectorIds) {
                                                 drawInstance.setFeatureProperty(fid, "color", hex)
                                             }

--- a/client/src/src/views/mapView/mapViewComponent.tsx
+++ b/client/src/src/views/mapView/mapViewComponent.tsx
@@ -6,6 +6,12 @@ import MapboxDraw from '@mapbox/mapbox-gl-draw'
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
 // @ts-expect-error no declare file for rectangle mode
 import DrawRectangle from 'mapbox-gl-draw-rectangle-mode'
+import {
+    VECTOR_DRAFT_LINE_MODE,
+    VECTOR_DRAFT_POLYGON_MODE,
+    VectorDraftLineMode,
+    VectorDraftPolygonMode,
+} from '@/template/vector/vectorDraftDrawModes'
 import ToolPanel from './toolPanel'
 import LayerGroup from './layerGroup'
 import 'mapbox-gl/dist/mapbox-gl.css'
@@ -175,7 +181,9 @@ const MapContainer = forwardRef<HTMLDivElement, MapContainerProps>(({ onMapLoad,
                     userProperties: true,
                     modes: {
                         ...MapboxDrawAny.modes,
-                        draw_rectangle: DrawRectangle
+                        draw_rectangle: DrawRectangle,
+                        [VECTOR_DRAFT_LINE_MODE]: VectorDraftLineMode,
+                        [VECTOR_DRAFT_POLYGON_MODE]: VectorDraftPolygonMode,
                     },
                     styles: [
                         // Active point style

--- a/client/src/test/vectorDraftUndoManager.test.ts
+++ b/client/src/test/vectorDraftUndoManager.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { VectorDraftUndoManager } from '../src/template/vector/vectorDraftUndoManager'
+
+test('tracks vector draft vertex undo redo and restores from snapshot', () => {
+    const manager = new VectorDraftUndoManager({
+        type: 'line',
+        featureId: 'draft-1',
+        coordinates: [],
+    })
+
+    manager.addVertex([1, 1])
+    manager.addVertex([2, 2])
+
+    assert.deepEqual(manager.getCoordinates(), [[1, 1], [2, 2]])
+    assert.equal(manager.canUndo(), true)
+    assert.equal(manager.canRedo(), false)
+
+    manager.undo()
+    assert.deepEqual(manager.getCoordinates(), [[1, 1]])
+    assert.equal(manager.canRedo(), true)
+
+    manager.redo()
+    assert.deepEqual(manager.getCoordinates(), [[1, 1], [2, 2]])
+
+    manager.undo()
+    manager.addVertex([3, 3])
+    assert.deepEqual(manager.getCoordinates(), [[1, 1], [3, 3]])
+    assert.equal(manager.canRedo(), false)
+
+    const snapshot = manager.toSnapshot()
+    assert.equal(snapshot.currentVertexPosition, 2)
+
+    const restored = VectorDraftUndoManager.fromSnapshot(snapshot)
+    assert.deepEqual(restored.getCoordinates(), [[1, 1], [3, 3]])
+    assert.equal(restored.canUndo(), true)
+
+    restored.undo()
+    assert.deepEqual(restored.getCoordinates(), [[1, 1]])
+})
+
+test('requires enough vertices before finalizing a draft geometry', () => {
+    const line = new VectorDraftUndoManager({
+        type: 'line',
+        featureId: 'line-draft',
+        coordinates: [],
+    })
+    assert.equal(line.canFinalize(), false)
+    line.addVertex([0, 0])
+    assert.equal(line.canFinalize(), false)
+    line.addVertex([1, 1])
+    assert.equal(line.canFinalize(), true)
+
+    const polygon = new VectorDraftUndoManager({
+        type: 'polygon',
+        featureId: 'polygon-draft',
+        coordinates: [],
+    })
+    polygon.addVertex([0, 0])
+    polygon.addVertex([1, 0])
+    assert.equal(polygon.canFinalize(), false)
+    polygon.addVertex([1, 1])
+    assert.equal(polygon.canFinalize(), true)
+})


### PR DESCRIPTION
Introduce vector draft modes for line and polygon drawing, along with an undo manager to handle vertex operations. Enhance the VectorEdit component to support draft snapshots and provide keyboard shortcuts for undo/redo actions. Ensure proper binding of the patch editor after loading the topology.